### PR TITLE
Update blocksPerYear in interest rate model contracts.

### DIFF
--- a/contracts/BaseJumpRateModelV2.sol
+++ b/contracts/BaseJumpRateModelV2.sol
@@ -21,7 +21,7 @@ abstract contract BaseJumpRateModelV2 is InterestRateModel {
     /**
      * @notice The approximate number of blocks per year that is assumed by the interest rate model
      */
-    uint public constant blocksPerYear = 2102400;
+    uint public constant blocksPerYear = 7884000;
 
     /**
      * @notice The multiplier of utilization rate that gives the slope of the interest rate

--- a/contracts/JumpRateModel.sol
+++ b/contracts/JumpRateModel.sol
@@ -15,7 +15,7 @@ contract JumpRateModel is InterestRateModel {
     /**
      * @notice The approximate number of blocks per year that is assumed by the interest rate model
      */
-    uint public constant blocksPerYear = 2102400;
+    uint public constant blocksPerYear = 7884000;
 
     /**
      * @notice The multiplier of utilization rate that gives the slope of the interest rate

--- a/contracts/WhitePaperInterestRateModel.sol
+++ b/contracts/WhitePaperInterestRateModel.sol
@@ -16,7 +16,7 @@ contract WhitePaperInterestRateModel is InterestRateModel {
     /**
      * @notice The approximate number of blocks per year that is assumed by the interest rate model
      */
-    uint public constant blocksPerYear = 2102400;
+    uint public constant blocksPerYear = 7884000;
 
     /**
      * @notice The multiplier of utilization rate that gives the slope of the interest rate


### PR DESCRIPTION
Update constant storage variable `blocksPerYear` in JumpRateModel, WhitePaperInterestRateModel and BaseJumpRateModelV2 smart contracts; from 2102400 to 7884000.