### PR TITLE
Two improvements in Comptroller

### DIFF
--- a/contracts/Comptroller.sol
+++ b/contracts/Comptroller.sol
@@ -869,6 +869,8 @@ contract Comptroller is ComptrollerV7Storage, ComptrollerInterface, ComptrollerE
         compUnlockTimestamp = block.timestamp + lockTime;
         compAddress = compContractAddress;
 
+        _setCompSpeeds(106171178500000000000, 106171178500000000000);
+
         return uint(Error.NO_ERROR);
     }
 
@@ -1464,15 +1466,16 @@ contract Comptroller is ComptrollerV7Storage, ComptrollerInterface, ComptrollerE
      * @param borrowSpeed New borrow-side COMP speed for the protocol.
      */
     function _setCompSpeeds(uint supplySpeed, uint borrowSpeed) public {
-        require(adminOrInitializing(), "only admin can set comp speed");
         require(distributionSchedule.length > 0, "distribution schedule has not been set");
         for (uint i = 0; i < distributionSchedule.length; i++) {
             DistributionSchedule memory ds = distributionSchedule[i];
             if (block.timestamp < ds.timestamp) {
                 require(supplySpeed == ds.compSpeed && borrowSpeed == ds.compSpeed, "comp speed must be set according to the distribution schedule during first 3 years");
-                break;
+                setCompSpeedInternal(supplySpeed, borrowSpeed);
+                return;
             }
         }
+        require(adminOrInitializing(), "only admin can set comp speed");
         setCompSpeedInternal(supplySpeed, borrowSpeed);        
     }
 

--- a/deploy/002-comptroller.js
+++ b/deploy/002-comptroller.js
@@ -40,21 +40,11 @@ module.exports = async ({ getNamedAccounts, deployments }) => {
   const comptroller = Comptroller.attach(unitroller.address);
 
   if (ethers.constants.Zero.eq(await comptroller.compUnlockTimestamp())) {
-    console.log("Setting distribution schedule and UTDX claim unlock time...");
+    console.log("Initializing UTDX parameters...");
     await (
       await comptroller._initializeCompParameters(
         UTDX_CLAIM_UNLOCK_TIME,
         utdx.address
-      )
-    ).wait();
-  }
-
-  if (ethers.constants.Zero.eq(await comptroller.compSupplySpeed())) {
-    console.log("Setting comp speeds...");
-    await (
-      await comptroller._setCompSpeeds(
-        "106171178500000000000",
-        "106171178500000000000"
       )
     ).wait();
   }


### PR DESCRIPTION
- Call setCompSpeeds in initializeCompParameters to set comp speeds for the first week right away
- Permit non-admin execution of setCompSpeeds when distribution schedule values are enforced